### PR TITLE
Remove html highlight

### DIFF
--- a/syntax/ftl.vim
+++ b/syntax/ftl.vim
@@ -15,6 +15,9 @@
 "     * Missing boilerplates of vim syntax plugin
 "       * b:current_syntax is not defined. vim syntax plugin must define it.
 "       * if b:current_syntax is defined, do not load syntax plugin
+" 1.2 tyru:
+"     * Sorry, remove HTML highlight feature.
+"       because ":setfiletype html.ftl" is enough.
 "
 " Licensed under the MIT License (MIT):
 "

--- a/syntax/ftl.vim
+++ b/syntax/ftl.vim
@@ -48,17 +48,6 @@ endif
 
 syn case match
 
-" Load html syntax.
-function! s:load_html_syntax()
-    if (exists('b:ftl_no_html') && b:ftl_no_html)
-    \   || (exists('g:ftl_no_html') && g:ftl_no_html)
-        return
-    endif
-    runtime! syntax/html.vim
-    unlet b:current_syntax
-endfunction
-call s:load_html_syntax()
-
 " directives and interpolations
 syn region ftlStartDirective start=+<#+ end=+>+ contains=ftlKeyword, ftlDirective, ftlString, ftlComment
 syn region ftlEndDirective start=+</#+ end=+>+ contains=ftlDirective


### PR DESCRIPTION
Hi Stephan, Would you include this changes?
- remove html highlight. because I found that ":setfiletype html.ftl" is enough to do this...
- wrote v1.2 changelog. but I'm not the author. if you have uncommited changes for v1.2, you can ignore that commit.

Should I send an email to freemarker-devel if you would release v1.2 ?
